### PR TITLE
Overwrite existing function when sourcing vimrc

### DIFF
--- a/plugin/vim-mkdir-on-write.vim
+++ b/plugin/vim-mkdir-on-write.vim
@@ -5,7 +5,7 @@
 " TODO: Maybe add error handling.
 " TODO: Add a configurable feature to first ask the user before creating dirs.
 
-function s:MkNonExDir(file, buf)
+function! s:MkNonExDir(file, buf)
 	if empty(getbufvar(a:buf, '&buftype')) && a:file!~#'\v^\w+\:\/'
 		let dir=fnamemodify(a:file, ':h')
 		if !isdirectory(dir)


### PR DESCRIPTION
This change overwrites an existing `s:MkNonExDir` function if it exists.  This is only a problem when reloading your vimrc.
